### PR TITLE
small fix for channel names being mispelled

### DIFF
--- a/src/contents/channels.md
+++ b/src/contents/channels.md
@@ -33,7 +33,7 @@ _Relating to the YYJ Tech and local Vancouver Island community topics_
 | #learning | Share resources and ask questions in a learning-friendly environment | Open [\*](#apply) |
 | [#events](https://yyjtech.slack.com/archives/C18K0EX1S) | Vancouver Island-related tech events | [@Andrina Kelly](/channel-stewards#Andrina%20Kelly) |
 | [#meta](https://yyjtech.slack.com/archives/C34M16KA7) | Discussion of making YYJ Tech a better place | [@jen](/channel-stewards#Jen%20Reiher) |
-| #moving-to-vicoria | Advice and connections for people new to Victoria, BC | Open [\*](#apply) |
+| #moving-to-victoria | Advice and connections for people new to Victoria, BC | Open [\*](#apply) |
 | #openhack | A long-running Victoria tech event | Open [\*](#apply) |
 | #remote | A place to connect with others who work remotely | Open [\*](#apply) |
 | #shamelessplug | Brag about something you're up to - but please keep it focused to topics related to Vancouver Island | Open [\*](#apply) |
@@ -47,7 +47,7 @@ _Topics related to seeking or providing work opportunities_
 | [#buy-a-coffee](https://yyjtech.slack.com/archives/CGZ8GFFTQ) | Ask questions of people who have experience with specific Vancouver Island companies to learn if you'd like to apply there | [@Andrina Kelly](/channel-stewards#Andrina%20Kelly) |
 | #co-founder-hunt | Find others looking for a cofounder | Open [\*](#apply) |
 | [#contract-opportunities](https://yyjtech.slack.com/archives/C8TC8SC4W) | Post contracts or announce openness to contract work | [@Nik Richers](/channel-stewards#Nik%20Richers)  |
-| #interships-and-coops | For students and/or employers considering a coop/internship positions | Open [\*](#apply) |
+| #internships-and-coops | For students and/or employers considering a coop/internship positions | Open [\*](#apply) |
 | [#job-postings](https://yyjtech.slack.com/archives/C18KMMR4J) | Post available jobs. **Please use the form pinned at the top of the channel** | [@Nik Richers](/channel-stewards#Nik%20Richers) |
 | [#seeking-opportunities](https://yyjtech.slack.com/archives/C05HZ6UDSTA) | Post that you're available and looking for new opportunities | [@Nik Richers](/channel-stewards#Nik%20Richers)  | 
 


### PR DESCRIPTION
Two channels had been misspelled: 

#moving-to-victoria and #internships-and-coops

This PR fixes these issues.