### PR TITLE
Change CoC link to point to main

### DIFF
--- a/src/contents/homepage.yml
+++ b/src/contents/homepage.yml
@@ -14,7 +14,7 @@ homepage:
       - Use kindness to build community. 
       - Be curious to hear about the other person’s perspective. 
       - We all have to help to foster safer and braver spaces. 
-    terms: I agree to the <a href="https://github.com/yyjtech/code-of-conduct/blob/master/README.md" target="_blank" title="YYJ Tech Code of Conduct">YYJ Tech Code of Conduct</a>, and understand not following it will result in being removed from the group.
+    terms: I agree to the <a href="https://github.com/yyjtech/code-of-conduct/blob/main/README.md" target="_blank" title="YYJ Tech Code of Conduct">YYJ Tech Code of Conduct</a>, and understand not following it will result in being removed from the group.
     buttonLabel: Sign Up
     media: ../images/yyj-slack.png
     redirectUrl: https://join.slack.com/t/yyjtech/shared_invite/zt-2ydnr816c-dr51yGzxK2rGjPRkZL0q~A


### PR DESCRIPTION
For a bit our CoC wasn't working and it turns out we weren't forwarding to the `main` branch from ye olde `master`. Probably time to fix this URL which this PR does.

<img width="2522" height="1662" alt="Capto_ 2025-10-07_08-21-47_am" src="https://github.com/user-attachments/assets/0aa6235e-dafc-4aae-a8e3-2f22c196bf51" />
